### PR TITLE
fix: correct plugin return type and add types condition to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 	"module": "./dist/pinia-capacitor-persist.es.js",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/pinia-capacitor-persist.es.js",
 			"require": "./dist/pinia-capacitor-persist.umd.js"
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ const restoreState = (
 		});
 	});
 
-export const piniaCapacitorPersist = async ({ options, store }: PiniaPluginContext): Promise<void> => {
+export const piniaCapacitorPersist = ({ options, store }: PiniaPluginContext): void => {
 	if (options.persist?.enabled !== true) return;
 
 	const rules = {


### PR DESCRIPTION
**Summary**
- Remove unnecessary async keyword from piniaCapacitorPersist function. The function does not use await — it only assigns store.restored = restoreState(...). The async keyword forces the return type to Promise<void>, which is incompatible with Pinia's PiniaPlugin type that expects void | Partial<PiniaCustomProperties>. This causes a TypeScript error when calling pinia.use(piniaCapacitorPersist).
- Add "types" condition to the exports field in package.json. Without it, TypeScript cannot resolve the package's type declarations when using moduleResolution: "Bundler", because it looks for a .d.ts file adjacent to the JS entry point
  (pinia-capacitor-persist.es.d.ts) instead of finding index.d.ts. 

**Reproduction**

Any project using moduleResolution: "Bundler" (default in @vue/tsconfig) will get:

error TS2345: Argument of type '(...) => Promise<void>' is not assignable to parameter of type 'PiniaPlugin'.